### PR TITLE
Add cluster support for strict sessions and lazy write

### DIFF
--- a/cluster.md
+++ b/cluster.md
@@ -193,3 +193,12 @@ The save path for cluster based session storage takes the form of a PHP GET requ
   * _distribute_: phpredis will randomly distribute session reads between masters and any attached slaves (load balancing).
 * _auth (string, empty by default)_:  The password used to authenticate with the server prior to sending commands.
 * _stream (array)_: ssl/tls stream context options.
+
+### redis.session.early_refresh
+Under normal operation, the client will refresh the session's expiry ttl whenever the session is closed. However, we can save this additional round-trip by updating the ttl when the session is opened instead ( This means that sessions that have not been modified will not send further commands to the server ).
+
+To enable, set the following INI variable:
+```ini
+redis.session.early_refresh = 1
+```
+Note: This is disabled by default since it may significantly reduce the session lifetime for long-running scripts. Redis server version 6.2+ required.

--- a/redis.c
+++ b/redis.c
@@ -110,6 +110,7 @@ PHP_INI_BEGIN()
     PHP_INI_ENTRY("redis.session.lock_expire", "0", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY("redis.session.lock_retries", "100", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY("redis.session.lock_wait_time", "20000", PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("redis.session.early_refresh", "0", PHP_INI_ALL, NULL)
 PHP_INI_END()
 
 static const zend_module_dep redis_deps[] = {

--- a/redis_session.h
+++ b/redis_session.h
@@ -20,6 +20,9 @@ PS_READ_FUNC(rediscluster);
 PS_WRITE_FUNC(rediscluster);
 PS_DESTROY_FUNC(rediscluster);
 PS_GC_FUNC(rediscluster);
+PS_CREATE_SID_FUNC(rediscluster);
+PS_VALIDATE_SID_FUNC(rediscluster);
+PS_UPDATE_TIMESTAMP_FUNC(rediscluster);
 
 #endif
 #endif


### PR DESCRIPTION
 * [2079](https://github.com/phpredis/phpredis/issues/2079) ini setting redis.session.early_refresh to allow for session TTL updates on session start ( requires redis server version 6.2 or greater )
 * Enable cluster session support for strict mode sessions ( via PS_VALIDATE_SID_FUNC )
 * Cluster sessions used to write on every session, now we only write if the session has been modified.
 * Send EXPIRE instead of SETEX if sessioh has not been changed
 * If early refresh is enabled use GETEX for initial session read
 * When strict sessions are enabled, check whether the session exists first, validate sid and regenerate if necessary